### PR TITLE
when jelly kills player, typeof(targetPoint) == string "undefined"

### DIFF
--- a/plugins/jelly.js
+++ b/plugins/jelly.js
@@ -105,7 +105,7 @@ var jellyToyboxPlugin = {
 
             var targetPoint = this.findTarget();
 
-            if( typeof(targetPoint) == undefined ){
+            if( typeof(targetPoint) == "undefined" ){
                 return
             } else if( (targetPoint.x < this.x && this.xDir == 1) || (targetPoint.x > this.x && this.xDir == -1) ){
                 this.turnAround();


### PR DESCRIPTION
Caught an error with jelly doing the random enemy button challenge. When jelly killed the player, the `targetPoint == undefined` or `typeof(targetPoint) == "undefined"` or `!targetPoint` would work too.